### PR TITLE
provisioner: migration functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docker-machine*
+*.log

--- a/commands.go
+++ b/commands.go
@@ -60,13 +60,6 @@ type hostListItem struct {
 	SwarmConfig swarm.SwarmOptions
 }
 
-type certPathInfo struct {
-	CaCertPath     string
-	CaKeyPath      string
-	ClientCertPath string
-	ClientKeyPath  string
-}
-
 func sortHostListItemsByName(items []hostListItem) {
 	m := make(map[string]hostListItem, len(items))
 	s := make([]string, len(items))
@@ -1119,7 +1112,7 @@ func getMachineConfig(c *cli.Context) (*machineConfig, error) {
 // codegangsta/cli will not set the cert paths if the storage-path
 // is set to something different so we cannot use the paths
 // in the global options. le sigh.
-func getCertPathInfo(c *cli.Context) certPathInfo {
+func getCertPathInfo(c *cli.Context) libmachine.CertPathInfo {
 	// setup cert paths
 	caCertPath := c.GlobalString("tls-ca-cert")
 	caKeyPath := c.GlobalString("tls-ca-key")
@@ -1142,7 +1135,7 @@ func getCertPathInfo(c *cli.Context) certPathInfo {
 		clientKeyPath = filepath.Join(utils.GetMachineCertDir(), "key.pem")
 	}
 
-	return certPathInfo{
+	return libmachine.CertPathInfo{
 		CaCertPath:     caCertPath,
 		CaKeyPath:      caKeyPath,
 		ClientCertPath: clientCertPath,

--- a/libmachine/certs.go
+++ b/libmachine/certs.go
@@ -1,0 +1,10 @@
+package libmachine
+
+type CertPathInfo struct {
+	CaCertPath     string
+	CaKeyPath      string
+	ClientCertPath string
+	ClientKeyPath  string
+	ServerCertPath string
+	ServerKeyPath  string
+}

--- a/libmachine/filestore.go
+++ b/libmachine/filestore.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/docker/machine/libmachine/engine"
-	"github.com/docker/machine/libmachine/swarm"
 	"github.com/docker/machine/utils"
 )
 
@@ -34,7 +32,7 @@ func (s Filestore) loadHost(name string) (*Host, error) {
 		return nil, err
 	}
 
-	h := validateHost(host)
+	h := ValidateHost(host)
 	return h, nil
 }
 
@@ -148,23 +146,4 @@ func (s Filestore) RemoveActive() error {
 // active host
 func (s Filestore) activePath() string {
 	return filepath.Join(utils.GetMachineDir(), ".active")
-}
-
-// validates host config and modifies if needed
-// this is used for configuration updates
-func validateHost(host *Host) *Host {
-	if host.HostConfig.EngineConfig == nil {
-		host.HostConfig.EngineConfig = &engine.EngineOptions{}
-	}
-
-	if host.HostConfig.SwarmConfig == nil {
-		host.HostConfig.SwarmConfig = &swarm.SwarmOptions{
-			Address:   "",
-			Discovery: host.SwarmDiscovery,
-			Host:      host.SwarmHost,
-			Master:    host.SwarmMaster,
-		}
-	}
-
-	return host
 }

--- a/libmachine/host.go
+++ b/libmachine/host.go
@@ -41,6 +41,7 @@ type Host struct {
 	ServerCertPath string
 	ServerKeyPath  string
 	ClientCertPath string
+	ClientKeyPath  string
 }
 
 type HostOptions struct {
@@ -53,8 +54,14 @@ type HostOptions struct {
 }
 
 type HostMetadata struct {
-	DriverName string
-	HostConfig HostOptions
+	DriverName     string
+	HostConfig     HostOptions
+	StorePath      string
+	CaCertPath     string
+	PrivateKeyPath string
+	ServerCertPath string
+	ServerKeyPath  string
+	ClientCertPath string
 }
 
 func NewHost(name, driverName string, hostConfig *HostOptions) (*Host, error) {
@@ -262,7 +269,9 @@ func (h *Host) LoadConfig() error {
 		return err
 	}
 
-	authConfig := hostMetadata.HostConfig.AuthConfig
+	meta := ValidateHostMetadata(&hostMetadata)
+
+	authConfig := meta.HostConfig.AuthConfig
 
 	driver, err := drivers.NewDriver(hostMetadata.DriverName, h.Name, h.StorePath, authConfig.CaCertPath, authConfig.PrivateKeyPath)
 	if err != nil {

--- a/libmachine/validate.go
+++ b/libmachine/validate.go
@@ -1,0 +1,115 @@
+package libmachine
+
+import (
+	"path/filepath"
+
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/engine"
+	"github.com/docker/machine/libmachine/swarm"
+	"github.com/docker/machine/utils"
+)
+
+// validates host config and modifies if needed
+// this is used for configuration updates
+func ValidateHost(host *Host) *Host {
+	certInfo := getCertInfoFromHost(host)
+
+	if host.HostConfig == nil {
+		host.HostConfig = &HostOptions{}
+	}
+	if host.HostConfig.EngineConfig == nil {
+		host.HostConfig.EngineConfig = &engine.EngineOptions{}
+	}
+
+	if host.HostConfig.SwarmConfig == nil {
+		host.HostConfig.SwarmConfig = &swarm.SwarmOptions{
+			Address:   "",
+			Discovery: host.SwarmDiscovery,
+			Host:      host.SwarmHost,
+			Master:    host.SwarmMaster,
+		}
+	}
+
+	host.HostConfig.AuthConfig = &auth.AuthOptions{
+		StorePath:            host.StorePath,
+		CaCertPath:           certInfo.CaCertPath,
+		CaCertRemotePath:     "",
+		ServerCertPath:       certInfo.ServerCertPath,
+		ServerKeyPath:        certInfo.ServerKeyPath,
+		ClientKeyPath:        certInfo.ClientKeyPath,
+		ServerCertRemotePath: "",
+		ServerKeyRemotePath:  "",
+		PrivateKeyPath:       certInfo.CaKeyPath,
+		ClientCertPath:       certInfo.ClientCertPath,
+	}
+
+	return host
+}
+
+// validates host metadata and modifies if needed
+// this is used for configuration updates
+func ValidateHostMetadata(m *HostMetadata) *HostMetadata {
+	if m.HostConfig.EngineConfig == nil {
+		m.HostConfig.EngineConfig = &engine.EngineOptions{}
+	}
+
+	if m.HostConfig.AuthConfig == nil {
+		m.HostConfig.AuthConfig = &auth.AuthOptions{
+			StorePath:            m.StorePath,
+			CaCertPath:           m.CaCertPath,
+			CaCertRemotePath:     "",
+			ServerCertPath:       m.ServerCertPath,
+			ServerKeyPath:        m.ServerKeyPath,
+			ClientKeyPath:        "",
+			ServerCertRemotePath: "",
+			ServerKeyRemotePath:  "",
+			PrivateKeyPath:       m.PrivateKeyPath,
+			ClientCertPath:       m.ClientCertPath,
+		}
+	}
+
+	return m
+}
+
+func getCertInfoFromHost(h *Host) CertPathInfo {
+	// setup cert paths
+	caCertPath := h.CaCertPath
+	caKeyPath := h.PrivateKeyPath
+	clientCertPath := h.ClientCertPath
+	clientKeyPath := h.ClientKeyPath
+	serverCertPath := h.ServerCertPath
+	serverKeyPath := h.ServerKeyPath
+
+	if caCertPath == "" {
+		caCertPath = filepath.Join(utils.GetMachineCertDir(), "ca.pem")
+	}
+
+	if caKeyPath == "" {
+		caKeyPath = filepath.Join(utils.GetMachineCertDir(), "ca-key.pem")
+	}
+
+	if clientCertPath == "" {
+		clientCertPath = filepath.Join(utils.GetMachineCertDir(), "cert.pem")
+	}
+
+	if clientKeyPath == "" {
+		clientKeyPath = filepath.Join(utils.GetMachineCertDir(), "key.pem")
+	}
+
+	if serverCertPath == "" {
+		serverCertPath = filepath.Join(utils.GetMachineCertDir(), "server.pem")
+	}
+
+	if serverKeyPath == "" {
+		serverKeyPath = filepath.Join(utils.GetMachineCertDir(), "server-key.pem")
+	}
+
+	return CertPathInfo{
+		CaCertPath:     caCertPath,
+		CaKeyPath:      caKeyPath,
+		ClientCertPath: clientCertPath,
+		ClientKeyPath:  clientKeyPath,
+		ServerCertPath: serverCertPath,
+		ServerKeyPath:  serverKeyPath,
+	}
+}

--- a/libmachine/validate_test.go
+++ b/libmachine/validate_test.go
@@ -1,0 +1,5 @@
+package libmachine
+
+import (
+	"testing"
+)

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -14,6 +14,8 @@ fi
 MACHINE_BIN_NAME=docker-machine_$PLATFORM-$ARCH
 BATS_LOG=${MACHINE_ROOT}/bats.log
 
+truncate -s0 ${BATS_LOG}
+
 teardown() {
   echo "$BATS_TEST_NAME
 ----------

--- a/test/integration/helpers.bash
+++ b/test/integration/helpers.bash
@@ -12,6 +12,16 @@ else
     ARCH="386"
 fi
 MACHINE_BIN_NAME=docker-machine_$PLATFORM-$ARCH
+BATS_LOG=${MACHINE_ROOT}/bats.log
+
+teardown() {
+  echo "$BATS_TEST_NAME
+----------
+$output
+----------
+
+" >> ${BATS_LOG}
+}
 
 build_machine() {
     pushd $MACHINE_ROOT >/dev/null


### PR DESCRIPTION
This adds the "migration shim" function to be compatible with pre-0.2.0 configs.
